### PR TITLE
event added to block press

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const HeatMapBlock = ({ size, value, index, colors, colorsPercentage, maximumVal
     return null;
 
   return (
-    <TouchableOpacity onPress={() => onBlockPress({ value, index })} style={[styles.heatMapBlock, { backgroundColor: color, width: size, height: size }, style]}>
+    <TouchableOpacity onPress={(event) => {onBlockPress({ value, index, event })}} style={[styles.heatMapBlock, { backgroundColor: color, width: size, height: size }, style]}>
     </TouchableOpacity>
   );
 }


### PR DESCRIPTION
Just added it to my own code so thought id pull.

Adds the default "TouchableOpacity" event to the "onBlockPress" return.

Used for getting click position.